### PR TITLE
Add two papers in ACL 2024, and one paper in NeurIPS 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,9 @@ Awesome LLM compression research papers and tools to accelerate LLM training and
 
 - Scaling Law for Post-training after Model Pruning <br> Arxiv 2024 [[Paper]](https://arxiv.org/abs/2411.10272)
 
+- LEMON: Reviving Stronger and Smaller LMs from Larger LMs with Linear Parameter Fusion <br> ACL 2024 [[Paper]](https://aclanthology.org/2024.acl-long.434/)
+
+
 ### Distillation
 
 - Lifting the Curse of Capacity Gap in Distilling Language Models <br> ACL 2023 [[Paper]](https://arxiv.org/abs/2305.12129) [[Code]](https://github.com/GeneZC/MiniMoE)
@@ -996,6 +999,10 @@ Awesome LLM compression research papers and tools to accelerate LLM training and
 - KVSharer: Efficient Inference via Layer-Wise Dissimilar KV Cache Sharing <br> Arxiv 2024 [[Paper]](https://arxiv.org/abs/2410.18517) [[Code]](https://github.com/yangyifei729/KVSharer)
 
 - Not All Heads Matter: A Head-Level KV Cache Compression Method with Integrated Retrieval and Reasoning <br> Arxiv 2024 [[Paper]](https://arxiv.org/abs/2410.19318) [[Code]](https://github.com/Clement25/SharedLLM)
+
+- NACL: A General and Effective KV Cache Eviction Framework for LLMs at Inference Time <br> ACL 2024 [[Paper]](https://arxiv.org/abs/2408.03675) [[Code]](https://github.com/PaddlePaddle/Research/tree/master/NLP/ACL2024-NACL)
+
+- DHA: Learning Decoupled-Head Attention from Transformer Checkpoints via Adaptive Heads Fusion <br> NeurIPS 2024 [[Paper]](https://arxiv.org/abs/2406.06567)
 
 ### Other
 


### PR DESCRIPTION
- **NACL** in ACL 2024 for KV cache compression.
- **LEMON** in ACL 2024 for Pruning/Fusing LLMs to Small ones.
- **DHA** in NeurIPS 2024 for Adaptive Grouping KV-heads for Efficient Transformer.